### PR TITLE
Metrics prefix fix

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -18,7 +18,7 @@ const NODE_ENV = process.env.NODE_ENV;
 const SECRET_KEY = process.env.SESSIONKEY || 'development';
 const BASE_GROUP = process.env.BASE_GROUP;
 const GRAPHITE_HOSTNAME = process.env.GRAPHITE_HOSTNAME || '';
-const GRAPHITE_PREFIX = process.env.GRAPHITE_PREFIX || 'test';
+const GRAPHITE_PREFIX = process.env.GRAPHITE_PREFIX !== undefined ? process.env.GRAPHITE_PREFIX : 'test';
 
 let app = express();
 


### PR DESCRIPTION
Only default GRAPHITE_PREFIX to 'test' if the env is undefined. 
Production uses an empty string as the prefix and shouldn't default to 'test'.

(Hopefully this PR won't show commits back to May...)